### PR TITLE
Slight change to README, update .gitignore and make RealTimeData() a little flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.Rproj.user
+*.Rhistory
+*.RData
+.Ruserdata
+*.Rproj
+*.sqlite3
+

--- a/R/Real_Time_Data.r
+++ b/R/Real_Time_Data.r
@@ -54,27 +54,26 @@ RealTimeData <- function(base_url = "http://dd.weather.gc.ca/hydrometric", prov_
   # nicely from the data mart files
   colHeaders <- c("station_number", "date_time", "hg", "hg_grade", "hg_sym", "hg_code",
                   "qr", "qr_grade", "qr_sym", "qr_code")
-
+  
   # get hourly file
   h <- try(read.table(infile[1], header=TRUE, sep=",", stringsAsFactors=FALSE))
- 
+  
   if(class(h)=="try-error") {
     stop(sprintf("Station [%s] cannot be found within Province/Territory [%s]...url not located %s",
                  station_number, prov_terr_loc, infile[1]))
   }
   colnames(h) <- colHeaders
   h$date_time <- gsub("([+-]\\d\\d)(:)","\\1", h$date_time)
-  h$date_time <- strptime(h$date_time, "%FT%T%z", tz="UTC")
+  h$date_time <- as.POSIXct(strptime(h$date_time, "%FT%T%z", tz="UTC"))
   
   # get daily file
   d <- try(read.table(infile[2], header=TRUE, sep=",", stringsAsFactors=FALSE))
   colnames(d) <- colHeaders
   d$date_time <- gsub("([+-]\\d\\d)(:)","\\1", d$date_time)
-  d$date_time <- strptime(d$date_time, "%FT%T%z", tz="UTC")
+  d$date_time <- as.POSIXct(strptime(d$date_time, "%FT%T%z", tz="UTC"))
   
   # now merge the hourly + daily (hourly data overwrites daily where dates are the same)
   p <- which(d$date_time < min(h$date_time))
   output <- rbind(d[p,], h)
   return(output)
 }
-

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Getting **HYDAT** data in R takes 3 steps:
 
 Steps 1 and 3 require commands from the **RSQLite** package; step 2 requires a **HYDAT** command. This example extracts daily flow values for a given station.
 
+	library(RSQLite)
+	library(HYDAT)
 	HYDATfile <- 'Hydat.sqlite3'
 	WSCstation <- '05HG001'  # South Sask. River at Saskatoon
 	HYDAT <- dbConnect(SQLite(), HYDATfile)


### PR DESCRIPTION
No offense taken if this pull request is rejected. Just made a few changes that improve my workflow so I thought it may improve others. 

If I use the current version of HYDAT I haven`t found a way to choose more than one station at a time. So instead I need to use some sort of loop to get the data. For example:

```r
## Loading packages
devtools::install_github("CentreForHydrology/HYDAT")
library(HYDAT)
library(dplyr)
library(purrr)
library(RSQLite)
##Stations of interest
stations = c("07EF003","08MF005")
```
Then we can define a function containing a loop:
```r
multi_RealTimeData <- function(stations) {
  comb_df <- c()
  for(i in 1:length(stations)){
    u <- RealTimeData(prov_terr_loc="BC", station_number=stations[i])
    comb_df <- rbind(comb_df, u)
  }
}
multi_RealTimeData(stations)
```
This is quite a bit of code to accomplish this task. Fortunately there are many tools available that simplify this type of thing. The one that I like to use is the `purrr` package. Without going into purrr's usage, we can simplify the above code into one line:
```r
map_df(stations, ~RealTimeData(prov_terr_loc="BC", station_number=.x))
```
There is a slight speed gain using the `map_df()`. More important to the case to use `purrr::map_df` is the prevalence of the `tidyverse` tools. They are gaining widespread usage and it would useful IMO if `HYDAT` were able accommodate them.  You will however, notice that `RealTimeData()` in it's current form does not work with `map_df` because internally `dplyr::bind_rows` does not support `POSIXlt`. So this long message is to suggest a slight change to date/time format to accommodate those tools. I've made that change in the fork and `map_df()` runs correctly when that fork is installed:
```r
devtools::install_github("boshek/HYDAT")
library(HYDAT)
map_df(stations, ~RealTimeData(prov_terr_loc="BC", station_number=.x))
```

